### PR TITLE
fixed deployment artifact error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: build
-          path: build
+          name: public
+          path: public
 
   deploy:
     needs: build
@@ -41,8 +41,8 @@ jobs:
       - name: Download Build Artifact
         uses: actions/download-artifact@v3
         with:
-          name: build
-          path: build
+          name: public
+          path: public
 
       - name: remove old build
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
The pipeline couldn't upload artifacts since vite bundles into public folder and not the build folder